### PR TITLE
Improve item requeueing

### DIFF
--- a/meesee.py
+++ b/meesee.py
@@ -110,6 +110,7 @@ def run_worker(func, func_kwargs, on_failure_func, config, worker_id, init_kwarg
             if on_failure_func is not None:
                 sys.stdout.write('worker {worker_id} running failure handler {e}\n'.format(worker_id=worker_id, e=e))
                 on_failure_func(item, e, r, worker_id)
+            item = None
             time.sleep(0.1)  # Throttle restarting
 
         if config.get('timeout') is not None:

--- a/meesee.py
+++ b/meesee.py
@@ -102,7 +102,8 @@ def run_worker(func, func_kwargs, on_failure_func, config, worker_id, init_kwarg
             break
         except (KeyboardInterrupt, SystemExit):
             sys.stdout.write('worker {worker_id} stopped\n'.format(worker_id=worker_id))
-            r.first_inline_send(item)
+            if item is not None:
+                r.first_inline_send(item)
             break
         except Exception as e:
             sys.stdout.write('worker {worker_id} failed reason {e}\n'.format(worker_id=worker_id, e=e))


### PR DESCRIPTION
Proposes 2 small changes related to item re-queueing
1. Check that item is not None before re-queueing
2. Erase the item in the Exception handler. It is likely the item which is causing undefined behavior. To avoid the scenario of workers throwing around the item like a hot potato, we discard it.

I have some doubts of point 2 though. What if `func` has a bug and we discard valid items? I guess the question is, which of the two scenarios is more likely, and handle that one.